### PR TITLE
change #turn method to prevent repeat display_board rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Learn.co Curriculum
+
+We're really exited that you're about to contribute to the [open curriculum](https://learn.co/content-license) on [Learn.co](https://learn.co). If this is your first time contributing, please continue reading to learn how to make the most meaningful and useful impact possible.
+
+## Raising an Issue to Encourage a Contribution
+
+If you notice a problem with the curriculum that you believe needs improvement
+but you're unable to make the change yourself, you should raise a Github issue
+containing a clear description of the problem. Include relevant snippets of
+the content and/or screenshots if applicable. Curriculum owners regularly review
+issue lists and your issue will be prioritized and addressed as appropriate.
+
+## Submitting a Pull Request to Suggest an Improvement
+
+If you see an opportunity for improvement and can make the change yourself go
+ahead and use a typical git workflow to make it happen:
+
+* Fork this curriculum repository
+* Make the change on your fork, with descriptive commits in the standard format
+* Open a Pull Request against this repo
+
+A curriculum owner will review your change and approve or comment on it in due
+course.
+
+# Why Contribute?
+
+Curriculum on Learn is publicly and freely available under Learn's
+[Educational Content License](https://learn.co/content-license). By
+embracing an open-source contribution model, our goal is for the curriculum
+on Learn to become, in time, the best educational content the world has
+ever seen.
+
+We need help from the community of Learners to maintain and improve the
+educational content. Everything from fixing typos, to correcting
+out-dated information, to improving exposition, to adding better examples,
+to fixing tests—all contributions to making the curriculum more effective are
+welcome.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+#Learn.co Educational Content License
+
+Copyright (c) 2015 Flatiron School, Inc
+
+The Flatiron School, Inc. owns this Educational Content. However, the Flatiron School supports the development and availability of educational materials in the public domain. Therefore, the Flatiron School grants Users of the Flatiron Educational Content set forth in this repository certain rights to reuse, build upon and share such Educational Content subject to the terms of the Educational Content License set forth [here](http://learn.co/content-license) (http://learn.co/content-license). You must read carefully the terms and conditions contained in the Educational Content License as such terms govern access to and use of the Educational Content.  
+
+Flatiron School is willing to allow you access to and use of the Educational Content only on the condition that you accept all of the terms and conditions contained in the Educational Content License set forth [here](http://learn.co/content-license) (http://learn.co/content-license).  By accessing and/or using the Educational Content, you are agreeing to all of the terms and conditions contained in the Educational Content License.  If you do not agree to any or all of the terms of the Educational Content License, you are prohibited from accessing, reviewing or using in any way the Educational Content.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ A turn of Tic Tac Toe is composed of the following routine:
 
 1. Asking the user for their move by position 1-9.
 2. Receiving the user input.
-3. If the move is valid, make the move.
+3. If the move is valid, make the move and display the board to the user.
 4. If the move is invalid, ask for a new move until a valid move is received.
-5. Display the board after the valid move has been made.
 
 All these procedures will be wrapped into our `#turn` method. However, the majority of the logic for these procedures will be defined and encapsulated in individual methods (some of which you may have built previously).
 
@@ -28,10 +27,10 @@ ask for input
 get input
 if input is valid
   make the move for input
+  show the board
 else
   ask for input again until you get a valid input
 end
-show the board
 ```
 
 ## Instructions
@@ -175,7 +174,7 @@ Asking for input again is the hard part. We either need a mechanism to repeat th
 
 Calling a method from within itself is totally okay in programming, in fact, it is an elegant solution to some complex problems. **Recursion** is the repeated application of the same procedure. [Google it](https://www.google.com/search?q=recursion&oq=recursion&aqs=chrome..69i57j69i60l3j69i65l2.1630j0j1&sourceid=chrome&es_sm=119&ie=UTF-8) **there's an easter egg from Google developers on that page, can you find it?**
 
-If you are familiar with loops, that is a totally acceptable solution to the input validation problem as well.
+As you are already familiar with loops, that is a totally acceptable solution to the input validation problem as well.
 
 As you try to get it working, keep playing with `bin/turn` until it works as expected, endlessly asking you for a valid turn input. If you ever need to exit the CLI without giving an input, just hit `CTRL+C` (sometimes `ALT+C` or `COMMAND+C`).
 
@@ -401,3 +400,5 @@ Please enter 1-9:
 Another issue, besides only marking Xs as described above, is that the game played way too many turns! We need it to know how to quit if someone wins.
 
 Even with these deficiencies, this `#turn` method means you are very close to building a complete Tic Tac Toe. Get excited!
+
+<p data-visibility='hidden'>View <a href='https://learn.co/lessons/ttt-8-turn' title='Building a Tic Tac Toe Turn'>Building a Tic Tac Toe Turn</a> on Learn.co and start learning to code for free.</p>

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -21,10 +21,10 @@ def turn(board)
   input = gets.strip
   if valid_move?(board, input)
     move(board, input)
+    display_board(board)
   else
-    turn(board) and return
+    turn(board)
   end
-  display_board(board)
 end
 
 def position_taken?(board, location)


### PR DESCRIPTION
Calling `turn` recursively on invalid user input causes the `display_board` method to render numerous times on the method return. Moved the `display_board` call to only be called on valid input.
@PeterBell 